### PR TITLE
Create manifest.json

### DIFF
--- a/sensors/desktop/chrome/manifest.json
+++ b/sensors/desktop/chrome/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Precog Sensor",
+  "version": "1.0",
+  "description": "Monitors web browsing activities and sends visited URLS to precog server for analysis",
+  "permissions": ["http://www.precok.org/*", "tabs", "activeTab", "storage"],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  
+  "manifest_version": 2
+}


### PR DESCRIPTION
First part of basic chrome spy extension that monitores visited urls and sends them to precog server.
Most obvious todos:
- get a real user id
- make the precog server url configurable?

Open question: who would really install this? Even during testing I had a bad "somebody is watching me" feeling...

2nd commit containg background.js is following